### PR TITLE
Don't run Docker in detached mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The native image can also be executed from command line (if the `native.name` pr
 
 Run `mvn clean package -P native-image-docker` to build a Linux docker image.
 
-Run `docker run -d --name helidon-native -p 8099:8099 helidon/example-graal:1.0.0-SNAPSHOT` to run the Docker container based on the image
+Run `docker run --name helidon-native -p 8099:8099 helidon/example-graal:1.0.0-SNAPSHOT` to run the Docker container based on the image
 
 See configuration of docker plugin in profile `native-image-docker` in `pom.xml`
   


### PR DESCRIPTION
I recommend to not run Docker in detached mode to avoid the issue where the App is running in Docker (detached, and hence the user might have forgot about that app), the app is updated and re-run (eg. using a plain JVM), there are some corner cases where the updated app will start without complaining about the port already being used by the app in Docker.
